### PR TITLE
0.1.13 Release

### DIFF
--- a/src/assetto_corsa/car/acd_utils.rs
+++ b/src/assetto_corsa/car/acd_utils.rs
@@ -145,7 +145,7 @@ impl AcdArchive {
 
     pub fn unpack_to(&self, out_path: &Path) -> Result<()> {
         if !out_path.is_dir() {
-            std::fs::create_dir(out_path).unwrap();
+            fs::create_dir(out_path)?;
         }
         for (filename, unpacked_buffer) in &self.contents.files {
             fs::write(out_path.join(filename), unpacked_buffer)?;

--- a/src/assetto_corsa/car/acd_utils.rs
+++ b/src/assetto_corsa/car/acd_utils.rs
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn extract_acd() {
-        let path = Path::new("/home/josykes/.steam/debian-installation/steamapps/common/assettocorsa/content/cars/ks_audi_r8_plus/data.acd");
+        let path = Path::new("/home/josykes/.steam/debian-installation/steamapps/common/assettocorsa/content/cars/ks_ferrari_f2004/data.acd");
         AcdArchive::load_from_acd_file(path).unwrap().unpack().unwrap();
     }
 

--- a/src/assetto_corsa/car/data/ai/gears.rs
+++ b/src/assetto_corsa/car/data/ai/gears.rs
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c):
+ * 2022 zephyrj
+ * zephyrj@protonmail.com
+ *
+ * This file is part of engine-crane.
+ *
+ * engine-crane is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * engine-crane is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with engine-crane. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::assetto_corsa::car::data::ai::Ai;
+use crate::assetto_corsa::ini_utils;
+use crate::assetto_corsa::error::{Result, Error, ErrorKind};
+use crate::assetto_corsa::ini_utils::{Ini, MissingMandatoryProperty};
+use crate::assetto_corsa::traits::{CarDataFile, CarDataUpdater, MandatoryDataSection};
+
+#[derive(Debug)]
+pub struct Gears {
+    pub up: i32,
+    pub down: i32,
+    pub slip_threshold: f64,
+    pub gas_cutoff_time: f64
+}
+
+impl Gears {
+    fn _load(ini_data: &Ini) -> std::result::Result<Gears, MissingMandatoryProperty> {
+        let up = ini_utils::get_mandatory_property(ini_data, "GEARS", "UP")?;
+        let down = ini_utils::get_mandatory_property(ini_data, "GEARS", "DOWN")?;
+        let slip_threshold = ini_utils::get_mandatory_property(ini_data, "GEARS", "SLIP_THRESHOLD")?;
+        let gas_cutoff_time = ini_utils::get_mandatory_property(ini_data, "GEARS", "GAS_CUTOFF_TIME")?;
+        Ok(Gears{ up, down, slip_threshold, gas_cutoff_time })
+    }
+}
+
+impl MandatoryDataSection for Gears {
+    fn load_from_parent(parent_data: &dyn CarDataFile) -> Result<Self> where Self: Sized {
+        return match Gears::_load(parent_data.ini_data()) {
+            Ok(g) => { Ok(g) }
+            Err(e) => {
+                Err(Error::new(
+                    ErrorKind::InvalidCar,
+                    format!("Missing {}.{} in {}", e.section_name, e.property_name, Ai::INI_FILENAME)
+                ))
+            }
+        }
+    }
+}
+
+impl CarDataUpdater for Gears {
+    fn update_car_data(&self, car_data: &mut dyn CarDataFile) -> Result<()> {
+        let ini_data = car_data.mut_ini_data();
+        ini_utils::set_value(ini_data, "GEARS", "UP", self.up);
+        ini_utils::set_value(ini_data, "GEARS", "DOWN", self.down);
+        ini_utils::set_float(ini_data, "GEARS", "SLIP_THRESHOLD", self.slip_threshold, 2);
+        ini_utils::set_float(ini_data, "GEARS", "GAS_CUTOFF_TIME", self.gas_cutoff_time, 2);
+        Ok(())
+    }
+}

--- a/src/assetto_corsa/car/data/ai/mod.rs
+++ b/src/assetto_corsa/car/data/ai/mod.rs
@@ -1,0 +1,81 @@
+/*
+Copyright (c):
+2022 zephyrj
+zephyrj@protonmail.com
+
+This file is part of engine-crane.
+
+engine-crane is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+engine-crane is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with engine-crane. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+pub mod gears;
+
+use crate::assetto_corsa::car::Car;
+use crate::assetto_corsa::ini_utils::Ini;
+use crate::assetto_corsa::error::{Result, Error, ErrorKind};
+use crate::assetto_corsa::ini_utils;
+use crate::assetto_corsa::traits::{CarDataFile, DataInterface};
+
+#[derive(Debug)]
+pub struct Ai<'a> {
+    car: &'a mut Car,
+    ini_data: Ini,
+}
+
+impl<'a> Ai<'a> {
+    pub const INI_FILENAME: &'static str = "ai.ini";
+
+    pub fn from_car(car: &'a mut Car) -> Result<Option<Ai<'a>>> {
+        match car.data_interface.get_file_data(Ai::INI_FILENAME)? {
+            None => Ok(None),
+            Some(file_data) => {
+                Ok(Some(Ai {
+                    car,
+                    ini_data: Ini::load_from_string(String::from_utf8_lossy(file_data.as_slice()).into_owned())
+                }))
+            }
+        }
+    }
+
+    pub fn write(&mut self) -> Result<()> {
+        let data_interface = self.car.mut_data_interface();
+        data_interface.update_file_data(Ai::INI_FILENAME,
+                                        self.ini_data.to_bytes());
+        data_interface.write()?;
+        Ok(())
+    }
+}
+
+impl<'a> CarDataFile for Ai<'a> {
+    fn ini_data(&self) -> &Ini {
+        &self.ini_data
+    }
+    fn mut_ini_data(&mut self) -> &mut Ini {
+        &mut self.ini_data
+    }
+    fn data_interface(&self) -> &dyn DataInterface {
+        self.car.data_interface()
+    }
+    fn mut_data_interface(&mut self) -> &mut dyn DataInterface {
+        self.car.mut_data_interface()
+    }
+}
+
+fn mandatory_field_error(section: &str, key: &str) -> Error {
+    return Error::new(
+        ErrorKind::InvalidCar,
+        format!("Missing {}.{} in {}", section, key, Ai::INI_FILENAME)
+    )
+}
+

--- a/src/assetto_corsa/car/data/ai/mod.rs
+++ b/src/assetto_corsa/car/data/ai/mod.rs
@@ -20,12 +20,15 @@ along with engine-crane. If not, see <https://www.gnu.org/licenses/>.
 */
 
 pub mod gears;
+pub use gears::Gears;
 
 use crate::assetto_corsa::car::Car;
 use crate::assetto_corsa::ini_utils::Ini;
 use crate::assetto_corsa::error::{Result, Error, ErrorKind};
-use crate::assetto_corsa::ini_utils;
 use crate::assetto_corsa::traits::{CarDataFile, DataInterface};
+
+
+pub const INI_FILENAME: &'static str = "ai.ini";
 
 #[derive(Debug)]
 pub struct Ai<'a> {
@@ -34,7 +37,7 @@ pub struct Ai<'a> {
 }
 
 impl<'a> Ai<'a> {
-    pub const INI_FILENAME: &'static str = "ai.ini";
+    pub const INI_FILENAME: &'static str = INI_FILENAME;
 
     pub fn from_car(car: &'a mut Car) -> Result<Option<Ai<'a>>> {
         match car.data_interface.get_file_data(Ai::INI_FILENAME)? {

--- a/src/assetto_corsa/car/data/engine/metadata.rs
+++ b/src/assetto_corsa/car/data/engine/metadata.rs
@@ -25,6 +25,7 @@ use std::fs::File;
 use std::path::Path;
 use toml::Value;
 use toml::value::Table;
+use tracing::error;
 use crate::assetto_corsa::error::{Result};
 use crate::assetto_corsa::car::lut_utils::load_lut_from_path;
 
@@ -199,10 +200,20 @@ impl Metadata {
     }
 
     pub fn set_string_value(&mut self, key: String, val: String) -> Option<toml::Value> {
-        self.toml_config.as_table_mut().unwrap().insert(key, toml::Value::String(val))
+        return if let Some(table) = self.toml_config.as_table_mut() {
+            table.insert(key, toml::Value::String(val))
+        } else {
+            error!("Failed to get metadata toml config as a table");
+            None
+        }
     }
 
     pub fn set_int_value(&mut self, key: String, val: i64) -> Option<toml::Value> {
-        self.toml_config.as_table_mut().unwrap().insert(key, toml::Value::Integer(val))
+        return if let Some(table) = self.toml_config.as_table_mut() {
+            table.insert(key, toml::Value::Integer(val))
+        } else {
+            error!("Failed to get metadata toml config as a table");
+            None
+        }
     }
 }

--- a/src/assetto_corsa/car/data/engine/power_curve.rs
+++ b/src/assetto_corsa/car/data/engine/power_curve.rs
@@ -25,26 +25,31 @@ use crate::assetto_corsa::error::{Result, Error, ErrorKind};
 
 #[derive(Debug)]
 pub struct PowerCurve {
-    power_lut: LutProperty<i32, i32>,
+    power_lut: LutProperty<i32, f64>,
 }
 
 impl PowerCurve {
-    pub fn update(&mut self, power_vec: Vec<(i32, i32)>) -> Result<Vec<(i32, i32)>> {
+    pub fn update(&mut self, power_vec: Vec<(i32, f64)>) -> Result<Vec<(i32, f64)>> {
         Ok(self.power_lut.update(power_vec))
     }
 }
 
 impl MandatoryDataSection for PowerCurve {
     fn load_from_parent(parent_data: &dyn CarDataFile) -> Result<Self> where Self: Sized {
-        Ok(PowerCurve{
-            power_lut: LutProperty::mandatory_from_ini(
-                String::from("HEADER"),
-                String::from("POWER_CURVE"),
-                parent_data.ini_data(),
-                parent_data.data_interface()).map_err(|err|{
-                Error::new(ErrorKind::InvalidCar, format!("Cannot find a lut for power curve. {}", err.to_string()))
-            })?
-        })
+        let power_lut = match LutProperty::<i32, f64>::mandatory_from_ini(
+            String::from("HEADER"),
+            String::from("POWER_CURVE"),
+            parent_data.ini_data(),
+            parent_data.data_interface()) {
+            Ok(lut) => {
+                lut
+            }
+            Err(e) => {
+                return Err(Error::new(ErrorKind::InvalidCar,
+                                      format!("Failed to load power curve lut from ini. {}", e)));
+            }
+        };
+        Ok(PowerCurve{ power_lut })
     }
 }
 

--- a/src/assetto_corsa/car/data/mod.rs
+++ b/src/assetto_corsa/car/data/mod.rs
@@ -23,6 +23,7 @@ pub mod car_ini_data;
 pub mod drivetrain;
 pub mod engine;
 pub mod digital_instruments;
+pub mod ai;
 
 pub use car_ini_data::CarIniData;
 pub use engine::Engine;

--- a/src/assetto_corsa/car/lut_utils.rs
+++ b/src/assetto_corsa/car/lut_utils.rs
@@ -26,6 +26,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use csv::Terminator;
+use serde::de::Unexpected::Str;
 use tracing::error;
 use crate::assetto_corsa::traits::DataInterface;
 
@@ -218,7 +219,7 @@ pub fn load_lut_from_reader<K, V, R>(lut_reader: R, delimiter: u8, terminator: T
         R: io::Read
 {
     let mut lut_data: Vec<(K, V)> = Vec::new();
-    let mut rdr = csv::ReaderBuilder::new().has_headers(false).delimiter(delimiter).terminator(terminator).from_reader(lut_reader);
+    let mut rdr = csv::ReaderBuilder::new().has_headers(false).delimiter(delimiter).terminator(terminator).comment(Some(b';')).from_reader(lut_reader);
     for result in rdr.records() {
         match result {
             Ok(record) => {

--- a/src/assetto_corsa/car/structs.rs
+++ b/src/assetto_corsa/car/structs.rs
@@ -121,6 +121,7 @@ impl<K,V> LutProperty<K, V>
     pub fn get_type(&self) -> &LutType<K, V> {
         &self.lut
     }
+
 }
 
 impl <K,V> CarDataUpdater for LutProperty<K, V>

--- a/src/assetto_corsa/car/ui/car_ui_data.rs
+++ b/src/assetto_corsa/car/ui/car_ui_data.rs
@@ -121,6 +121,15 @@ impl UiInfo {
         None
     }
 
+    pub fn has_tag(&self, tag: &str) -> bool {
+        if let Some(value) = self.json_config.get("tags") {
+            if let Some(list) = value.as_array() {
+                return list.contains(&serde_json::Value::String(tag.to_string()));
+            }
+        }
+        false
+    }
+
     pub fn add_tag(&mut self, new_tag: String) {
         let obj = self.json_config.as_object_mut().unwrap();
         if let Some(value) = obj.get_mut("tags") {
@@ -128,6 +137,20 @@ impl UiInfo {
                 list.push(serde_json::Value::String(new_tag));
             }
         }
+    }
+
+    pub fn add_tag_if_unique(&mut self, new_tag: String) -> bool {
+        let obj = self.json_config.as_object_mut().unwrap();
+        if let Some(value) = obj.get_mut("tags") {
+            if let Some(list) = value.as_array_mut() {
+                let new_tag = serde_json::Value::String(new_tag);
+                if !list.contains(&new_tag) {
+                    list.push(new_tag);
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub fn specs(&self) -> Option<HashMap<&str, SpecValue>> {

--- a/src/assetto_corsa/error.rs
+++ b/src/assetto_corsa/error.rs
@@ -96,6 +96,8 @@ pub enum ErrorKind {
     JsonDecodeError,
     TomlDecodeError,
     AcdError,
+    UpdateError,
+    ArgumentError,
     Uncategorized
 }
 
@@ -111,7 +113,9 @@ impl ErrorKind {
             ErrorKind::JsonDecodeError => "json decode error",
             ErrorKind::TomlDecodeError => "toml decode error",
             ErrorKind::AcdError => "acd decode error",
-            ErrorKind::Uncategorized => "uncategorized error"
+            ErrorKind::ArgumentError => "argument error",
+            ErrorKind::Uncategorized => "uncategorized error",
+            ErrorKind::UpdateError => "update error"
         }
     }
 }

--- a/src/assetto_corsa/ini_utils.rs
+++ b/src/assetto_corsa/ini_utils.rs
@@ -76,8 +76,8 @@ impl From<FieldTypeError> for Error {
 
 #[derive(Debug)]
 pub struct MissingMandatoryProperty {
-    section_name: String,
-    property_name: String
+    pub section_name: String,
+    pub property_name: String
 }
 
 impl MissingMandatoryProperty {

--- a/src/fabricator.rs
+++ b/src/fabricator.rs
@@ -94,20 +94,14 @@ impl Display for AssettoCorsaPhysicsLevel {
 
 pub struct AssettoCorsaCarSettings {
     pub minimum_physics_level: AssettoCorsaPhysicsLevel,
-}
-
-impl AssettoCorsaCarSettings {
-    pub fn from_physics_level(level: AssettoCorsaPhysicsLevel) -> AssettoCorsaCarSettings {
-        AssettoCorsaCarSettings {
-            minimum_physics_level: level,
-        }
-    }
+    pub auto_adjust_clutch: bool
 }
 
 impl Default for AssettoCorsaCarSettings {
     fn default() -> AssettoCorsaCarSettings {
-        AssettoCorsaCarSettings{
-            ..Default::default()
+        AssettoCorsaCarSettings {
+            minimum_physics_level: AssettoCorsaPhysicsLevel::default(),
+            auto_adjust_clutch: true
         }
     }
 }

--- a/src/ui/swap.rs
+++ b/src/ui/swap.rs
@@ -148,9 +148,11 @@ impl EngineSwapTab {
                         } else {
                             None
                         };
+                    let mut car_settings = AssettoCorsaCarSettings::default();
+                    car_settings.minimum_physics_level = self.current_minimum_physics;
                     match fabricator::swap_automation_engine_into_ac_car(mod_path.as_path(),
                                                                          new_car_path.as_path(),
-                                                                         AssettoCorsaCarSettings::from_physics_level(self.current_minimum_physics),
+                                                                         car_settings,
                                                                          AdditionalAcCarData::new(current_engine_weight)) {
                         Ok(_) => { self.status_message = format!("Created {} successfully", new_car_path.display()) }
                         Err(err_str) => { self.status_message = err_str }


### PR DESCRIPTION
- Remove a number of usages of unwrap() and replace with sensible errors
- Delete the car folder if an engine-swap is unsuccessful
- Update the ai shift points when performing an engine swap
- Handle comments in .lut files (to support VRC's Formula Beta)
- Handle float values in .lut files (to support VRC's Formula Beta)